### PR TITLE
使用protobuf3时，支持repeated修饰的简单类型（例如:repeated int32）

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -328,7 +328,7 @@ pbc_decode(struct pbc_env * env, const char * type_name , struct pbc_slice * sli
 				_pbcC_close(_ctx);
 				return -i-1;
 			}
-		} else if (f->label == LABEL_PACKED) {
+		} else if (f->label == LABEL_PACKED || f->label == LABEL_REPEATED) {
 			struct atom * a = &ctx->a[i];
 			int n = call_array(pd, ud, f , start + a->v.s.start , a->v.s.end - a->v.s.start);
 			if (n < 0) {


### PR DESCRIPTION
在我们项目中，发现协议里面加了类似repeated int32的类型，客户端不论发多少个数字，pbc只能解析出来一个错误的数字